### PR TITLE
Typo

### DIFF
--- a/src/PeezyWin.cpp
+++ b/src/PeezyWin.cpp
@@ -29,7 +29,7 @@ void PeezyWin::popScene() { scenes.pop(); }
 
 void PeezyWin::changeScene(Scene* sc)
 {
-  if(scenes.empty()) popScene();
+  if(!scenes.empty()) popScene();
   pushScene(sc);
   return;
 }


### PR DESCRIPTION
Missing negation.

Also, it would be a good idea to change popScene so it deletes scenes.top() before popping, to prevent memory leaks.
